### PR TITLE
Added support for timestamped data

### DIFF
--- a/app/src/main/java/cz/mroczis/netmonster/sample/view/CellView.kt
+++ b/app/src/main/java/cz/mroczis/netmonster/sample/view/CellView.kt
@@ -28,6 +28,7 @@ class CellView @JvmOverloads constructor(
             cell.pci?.let { addView("PCI", it) }
             cell.bandwidth?.let { addView("BW", it) }
 
+            cell.timestamp?.let { addView("Timestamp", it) }
             cell.signal.let { signal ->
                 signal.rssi?.let { addView("RSSI", it) }
                 signal.rsrp?.let { addView("RSRP", it) }

--- a/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellCdma.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellCdma.kt
@@ -49,7 +49,8 @@ data class CellCdma(
 
     override val signal: SignalCdma,
     override val connectionStatus: IConnection,
-    override val subscriptionId: Int
+    override val subscriptionId: Int,
+    override val timestamp: Long? = null
 ) : ICell {
 
     /**

--- a/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellGsm.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellGsm.kt
@@ -42,7 +42,8 @@ data class CellGsm(
 
     override val signal: SignalGsm,
     override val connectionStatus: IConnection,
-    override val subscriptionId: Int
+    override val subscriptionId: Int,
+    override val timestamp: Long? = null
 ) : ICell {
 
     /**

--- a/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellLte.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellLte.kt
@@ -44,7 +44,8 @@ data class CellLte(
 
     override val signal: SignalLte,
     override val connectionStatus: IConnection,
-    override val subscriptionId: Int
+    override val subscriptionId: Int,
+    override val timestamp: Long? = null
 ) : ICell {
 
     /**
@@ -68,6 +69,7 @@ data class CellLte(
         get() = if (network != null && eci != null) {
             "${network.toPlmn()}${eci.toString().padStart(10, '0')}"
         } else null
+
 
     override fun <T> let(processor: ICellProcessor<T>): T = processor.processLte(this)
 

--- a/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellNr.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellNr.kt
@@ -38,7 +38,8 @@ data class CellNr(
     override val band: BandNr?,
     override val signal: SignalNr,
     override val connectionStatus: IConnection,
-    override val subscriptionId: Int
+    override val subscriptionId: Int,
+    override val timestamp: Long? = null
 ) : ICell {
 
     override fun <T> let(processor: ICellProcessor<T>): T = processor.processNr(this)

--- a/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellTdscdma.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellTdscdma.kt
@@ -12,6 +12,7 @@ import cz.mroczis.netmonster.core.model.cell.CellTdscdma.Companion.LAC_MAX
 import cz.mroczis.netmonster.core.model.cell.CellTdscdma.Companion.LAC_MIN
 import cz.mroczis.netmonster.core.model.connection.IConnection
 import cz.mroczis.netmonster.core.model.signal.SignalTdscdma
+import java.sql.Timestamp
 
 @SinceSdk(Build.VERSION_CODES.Q)
 data class CellTdscdma(
@@ -40,7 +41,8 @@ data class CellTdscdma(
 
     override val signal: SignalTdscdma,
     override val connectionStatus: IConnection,
-    override val subscriptionId: Int
+    override val subscriptionId: Int,
+    override val timestamp: Long? = null,
 ) : ICell {
 
     /**

--- a/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellWcdma.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellWcdma.kt
@@ -37,7 +37,8 @@ data class CellWcdma(
 
     override val signal: SignalWcdma,
     override val connectionStatus: IConnection,
-    override val subscriptionId: Int
+    override val subscriptionId: Int,
+    override val timestamp: Long? = null
 ) : ICell {
 
     /**

--- a/library/src/main/java/cz/mroczis/netmonster/core/model/cell/ICell.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/model/cell/ICell.kt
@@ -8,7 +8,6 @@ import cz.mroczis.netmonster.core.model.connection.IConnection
 import cz.mroczis.netmonster.core.model.signal.ISignal
 
 interface ICell {
-
     /**
      * Subscription id into which cell is bound to, [Int.MAX_VALUE] if
      * subscriptions are not supported yet
@@ -37,6 +36,11 @@ interface ICell {
      * Generally null for non-serving cells if no postprocessing is done.
      */
     val network: Network?
+
+    /**
+     *  Timestamp of this cell data
+     */
+    val timestamp: Long?
 
     /**
      * Using visitor pattern invokes one method of [processor]

--- a/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/CellInfoMapper.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/CellInfoMapper.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.annotation.TargetApi
 import android.os.Build
 import android.telephony.*
+import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
 import cz.mroczis.netmonster.core.model.cell.ICell
 import cz.mroczis.netmonster.core.telephony.mapper.cell.mapCell
@@ -37,43 +38,57 @@ class CellInfoMapper(
         } ?: emptyList()
 
 
+    private fun getTimeStamp(model: CellInfo): Long {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            model.timestampMillis
+        } else {
+            model.timeStamp
+        }
+    }
+
     private fun mapGsm(model: CellInfoGsm): ICell? {
         val connection = model.mapConnection()
         val signal = model.cellSignalStrength.mapSignal()
-        return model.cellIdentity.mapCell(subId, connection, signal)
+        val timestamp = getTimeStamp(model)
+        return model.cellIdentity.mapCell(subId, connection, signal, timestamp)
     }
 
     private fun mapLte(model: CellInfoLte): ICell? {
         val connection = model.mapConnection()
         val signal =  model.cellSignalStrength.mapSignal()
-        return model.cellIdentity.mapCell(subId, connection, signal)
+        val timestamp = getTimeStamp(model)
+        return model.cellIdentity.mapCell(subId, connection, signal, timestamp)
     }
 
     private fun mapCdma(model: CellInfoCdma): ICell? {
         val connection = model.mapConnection()
         val signal = model.cellSignalStrength.mapSignal()
-        return model.cellIdentity.mapCell(subId, connection, signal)
+        val timestamp = getTimeStamp(model)
+        return model.cellIdentity.mapCell(subId, connection, signal, timestamp)
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     private fun mapWcdma(model: CellInfoWcdma): ICell? {
         val connection = model.mapConnection()
         val signal = model.cellSignalStrength.mapSignal()
-        return model.cellIdentity.mapCell(subId, connection, signal)
+        val timestamp = getTimeStamp(model)
+        return model.cellIdentity.mapCell(subId, connection, signal, timestamp)
     }
 
     @TargetApi(Build.VERSION_CODES.Q)
     private fun mapTdscdma(model: CellInfoTdscdma): ICell? {
         val connection = model.mapConnection()
         val signal = model.cellSignalStrength.mapSignal()
-        return model.cellIdentity.mapCell(subId, connection, signal)
+        val timestamp = getTimeStamp(model)
+        return model.cellIdentity.mapCell(subId, connection, signal, timestamp)
     }
 
     @TargetApi(Build.VERSION_CODES.Q)
     private fun mapNr(model: CellInfoNr): ICell? {
         val connection = model.mapConnection()
         val signal = (model.cellSignalStrength as? CellSignalStrengthNr)?.mapSignal()
-        return (model.cellIdentity as? CellIdentityNr)?.mapCell(subId, connection, signal)
+        val timestamp = getTimeStamp(model)
+        return (model.cellIdentity as? CellIdentityNr)?.mapCell(subId, connection, signal, timestamp)
     }
 
 }

--- a/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/CellLocationMapper.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/CellLocationMapper.kt
@@ -52,17 +52,23 @@ class CellLocationMapper(
     override fun map(model: Int): List<ICell> {
         val scanResult = getUpdatedLocationAndSignal(model)
 
+        val timestamp = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            scanResult.signal?.timestampMillis
+        } else {
+            null
+        }
+
         return mutableListOf<ICell>().apply {
             if (scanResult.location is GsmCellLocation) {
-                map(scanResult.location, scanResult.signal, model)?.let { add(it) }
+                map(scanResult.location, scanResult.signal, model, timestamp)?.let { add(it) }
             } else if (scanResult.location is CdmaCellLocation) {
-                scanResult.location.mapCdma(model, scanResult.signal)?.let { add(it) }
+                scanResult.location.mapCdma(model, scanResult.signal, timestamp)?.let { add(it) }
             }
         }
     }
 
     @RequiresPermission(allOf = [Manifest.permission.READ_PHONE_STATE])
-    private fun map(model: GsmCellLocation, signalStrength: SignalStrength?, subId: Int): ICell? {
+    private fun map(model: GsmCellLocation, signalStrength: SignalStrength?, subId: Int, timestamp: Long?): ICell? {
         val network = NetworkTypeTable.get(telephony.networkType)
         val cid = model.cid
         val plmn = getNetworkOperator.invoke()
@@ -84,15 +90,15 @@ class CellLocationMapper(
         }
 
         return if (rsrp != null && network is NetworkType.Lte && !CellGsm.CID_RANGE.contains(cid)) {
-            model.mapLte(subId, signalStrength, plmn)
+            model.mapLte(subId, signalStrength, plmn, timestamp)
         } else if (SignalWcdma.RSCP_RANGE.contains(wcdma) && network is NetworkType.Wcdma) {
-            model.mapWcdma(subId, signalStrength, plmn)
+            model.mapWcdma(subId, signalStrength, plmn, timestamp)
         } else if (CellGsm.CID_RANGE.contains(cid) && (!CellWcdma.PSC_RANGE.contains(model.psc) || network is NetworkType.Gsm)) {
-            model.mapGsm(subId, signalStrength, plmn)
+            model.mapGsm(subId, signalStrength, plmn, timestamp)
         } else if (network is NetworkType.Wcdma || CellWcdma.PSC_RANGE.contains(model.psc)) {
-            model.mapWcdma(subId, signalStrength, plmn)
+            model.mapWcdma(subId, signalStrength, plmn, timestamp)
         } else if (network is NetworkType.Lte) {
-            model.mapLte(subId, signalStrength, plmn)
+            model.mapLte(subId, signalStrength, plmn, timestamp)
         } else {
             null
         }

--- a/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/NeighbouringCellInfoMapper.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/NeighbouringCellInfoMapper.kt
@@ -63,7 +63,8 @@ class NeighbouringCellInfoMapper(
                 band = null,
                 signal = SignalGsm(rssi, null, null),
                 connectionStatus = NoneConnection(),
-                subscriptionId = subId
+                subscriptionId = subId,
+                timestamp = null
             )
         } else null
     }
@@ -81,7 +82,8 @@ class NeighbouringCellInfoMapper(
                 band = null,
                 signal = SignalWcdma(rssi, null, null, null, null),
                 connectionStatus = NoneConnection(),
-                subscriptionId = subId
+                subscriptionId = subId,
+                timestamp = null
             )
         } else null
     }

--- a/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperCdma.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperCdma.kt
@@ -38,7 +38,7 @@ internal fun CellSignalStrengthCdma.mapSignal(): SignalCdma {
  * [CellIdentityCdma] -> [CellCdma]
  */
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
-internal fun CellIdentityCdma.mapCell(subId: Int, connection: IConnection, signal: SignalCdma): CellCdma? {
+internal fun CellIdentityCdma.mapCell(subId: Int, connection: IConnection, signal: SignalCdma, timestamp: Long): CellCdma? {
     val bid = basestationId.inRangeOrNull(CellCdma.BID_RANGE)
     val nid = networkId.inRangeOrNull(CellCdma.NID_RANGE)
     val sid = systemId.inRangeOrNull(CellCdma.SID_RANGE)
@@ -54,13 +54,14 @@ internal fun CellIdentityCdma.mapCell(subId: Int, connection: IConnection, signa
             lon = lon,
             signal = signal,
             connectionStatus = connection,
-            subscriptionId = subId
+            subscriptionId = subId,
+            timestamp = timestamp
         )
     } else null
 }
 
 @Suppress("DEPRECATION")
-internal fun CdmaCellLocation.mapCdma(subId: Int, signal: SignalStrength?): ICell? {
+internal fun CdmaCellLocation.mapCdma(subId: Int, signal: SignalStrength?, timestamp: Long?): ICell? {
     val bid = baseStationId.inRangeOrNull(CellCdma.BID_RANGE)
     val nid = networkId.inRangeOrNull(CellCdma.NID_RANGE)
     val sid = systemId.inRangeOrNull(CellCdma.SID_RANGE)
@@ -89,7 +90,8 @@ internal fun CdmaCellLocation.mapCdma(subId: Int, signal: SignalStrength?): ICel
                 evdoSnr = evdoSnr
             ),
             connectionStatus = PrimaryConnection(),
-            subscriptionId = subId
+            subscriptionId = subId,
+            timestamp = timestamp
         )
     } else null
 }

--- a/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperGsm.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperGsm.kt
@@ -18,6 +18,7 @@ import cz.mroczis.netmonster.core.model.signal.SignalGsm
 import cz.mroczis.netmonster.core.util.Reflection
 import cz.mroczis.netmonster.core.util.getGsmRssi
 import cz.mroczis.netmonster.core.util.inRangeOrNull
+import java.sql.Timestamp
 
 /**
  * [CellSignalStrengthGsm] -> [SignalGsm]
@@ -74,7 +75,8 @@ private fun CellSignalStrengthWcdma.mapWcdmaSignalToGsm(): SignalGsm {
 internal fun CellIdentityGsm.mapCell(
     subId: Int,
     connection: IConnection,
-    signal: SignalGsm
+    signal: SignalGsm,
+    timestamp: Long
 ): CellGsm? {
     val network = mapNetwork()
     val cid = cid.inRangeOrNull(CellGsm.CID_RANGE)
@@ -109,7 +111,8 @@ internal fun CellIdentityGsm.mapCell(
                 signal.copy(rssi = null)
             } else signal,
             band = band,
-            subscriptionId = subId
+            subscriptionId = subId,
+            timestamp = timestamp
         )
     } else null
 }
@@ -130,7 +133,8 @@ internal fun CellIdentityGsm.mapNetwork(): Network? =
 internal fun GsmCellLocation.mapGsm(
     subId: Int,
     signalStrength: SignalStrength?,
-    network: Network?
+    network: Network?,
+    timestamp: Long?
 ): ICell? {
     val cid = cid.inRangeOrNull(CellGsm.CID_RANGE)
     val lac = lac.inRangeOrNull(CellGsm.LAC_RANGE)
@@ -171,7 +175,8 @@ internal fun GsmCellLocation.mapGsm(
             signal = signal,
             network = network,
             connectionStatus = PrimaryConnection(),
-            subscriptionId = subId
+            subscriptionId = subId,
+            timestamp = timestamp
         )
     } else null
 }

--- a/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperLte.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperLte.kt
@@ -23,7 +23,7 @@ import kotlin.math.absoluteValue
  * [CellIdentityLte] -> [CellLte]
  */
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-internal fun CellIdentityLte.mapCell(subId: Int, connection: IConnection, signal: SignalLte): CellLte? {
+internal fun CellIdentityLte.mapCell(subId: Int, connection: IConnection, signal: SignalLte, timestamp: Long?): CellLte? {
     val network = mapNetwork()
     val ci = ci.inRangeOrNull(CellLte.CID_RANGE)
     val tac = tac.inRangeOrNull(CellLte.TAC_RANGE)
@@ -50,7 +50,8 @@ internal fun CellIdentityLte.mapCell(subId: Int, connection: IConnection, signal
         connectionStatus = connection,
         signal = signal,
         band = band,
-        subscriptionId = subId
+        subscriptionId = subId,
+        timestamp = timestamp
     )
 }
 
@@ -172,7 +173,7 @@ internal fun CellIdentityLte.mapNetwork(): Network? =
     }
 
 @Suppress("DEPRECATION")
-internal fun GsmCellLocation.mapLte(subId: Int, signalStrength: SignalStrength?, network: Network?): ICell? {
+internal fun GsmCellLocation.mapLte(subId: Int, signalStrength: SignalStrength?, network: Network?, timestamp: Long?): ICell? {
     val ci = cid.inRangeOrNull(CellLte.CID_RANGE)
     val tac = lac.inRangeOrNull(CellLte.TAC_RANGE)
 
@@ -221,7 +222,7 @@ internal fun GsmCellLocation.mapLte(subId: Int, signalStrength: SignalStrength?,
             rsrq = rsrq,
             cqi = cqi,
             snr = snr,
-            timingAdvance = null
+            timingAdvance = null,
         )
     }
 
@@ -235,7 +236,8 @@ internal fun GsmCellLocation.mapLte(subId: Int, signalStrength: SignalStrength?,
             bandwidth = null,
             signal = signal,
             connectionStatus = PrimaryConnection(),
-            subscriptionId = subId
+            subscriptionId = subId,
+            timestamp = timestamp
         )
     } else null
 }

--- a/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperNr.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperNr.kt
@@ -11,12 +11,13 @@ import cz.mroczis.netmonster.core.model.cell.CellNr
 import cz.mroczis.netmonster.core.model.connection.IConnection
 import cz.mroczis.netmonster.core.model.signal.SignalNr
 import cz.mroczis.netmonster.core.util.inRangeOrNull
+import java.sql.Timestamp
 
 /**
  * [CellIdentityNr] -> [CellNr]
  */
 @TargetApi(Build.VERSION_CODES.Q)
-internal fun CellIdentityNr.mapCell(subId: Int, connection: IConnection, signal: SignalNr?): CellNr? {
+internal fun CellIdentityNr.mapCell(subId: Int, connection: IConnection, signal: SignalNr?, timestamp: Long): CellNr? {
     val network = Network.map(mccString, mncString)
     val nci = nci.inRangeOrNull(CellNr.CID_RANGE)
     val tac = tac.inRangeOrNull(CellNr.TAC_RANGE)
@@ -38,7 +39,8 @@ internal fun CellIdentityNr.mapCell(subId: Int, connection: IConnection, signal:
         connectionStatus = connection,
         signal = signal ?: SignalNr(),
         band = band,
-        subscriptionId = subId
+        subscriptionId = subId,
+        timestamp = timestamp
     )
 }
 

--- a/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperTdscdma.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperTdscdma.kt
@@ -39,7 +39,7 @@ internal fun CellSignalStrengthTdscdma.mapSignal(): SignalTdscdma {
  * [CellIdentityTdscdma] -> [CellTdscdma]
  */
 @TargetApi(Build.VERSION_CODES.Q)
-internal fun CellIdentityTdscdma.mapCell(subId: Int, connection: IConnection, signal: SignalTdscdma): CellTdscdma? {
+internal fun CellIdentityTdscdma.mapCell(subId: Int, connection: IConnection, signal: SignalTdscdma, timestamp: Long): CellTdscdma? {
     val network =  Network.map(mccString, mncString)
     val ci = cid.inRangeOrNull(CellTdscdma.CID_RANGE)
     val lac = lac.inRangeOrNull(CellTdscdma.LAC_RANGE)
@@ -62,7 +62,8 @@ internal fun CellIdentityTdscdma.mapCell(subId: Int, connection: IConnection, si
             connectionStatus = connection,
             signal = signal,
             band = band,
-            subscriptionId = subId
+            subscriptionId = subId,
+            timestamp = timestamp
         )
     }
 }

--- a/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperWcdma.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperWcdma.kt
@@ -79,7 +79,7 @@ internal fun CellSignalStrengthWcdma.mapSignal(): SignalWcdma {
  * [CellIdentityWcdma] -> [CellWcdma]
  */
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-internal fun CellIdentityWcdma.mapCell(subId: Int, connection: IConnection, signal: SignalWcdma): CellWcdma? {
+internal fun CellIdentityWcdma.mapCell(subId: Int, connection: IConnection, signal: SignalWcdma, timestamp: Long): CellWcdma? {
     val network = mapNetwork()
     val lac = lac.inRangeOrNull(CellWcdma.LAC_RANGE)
     val ci = if (lac == null && cid < 100) {
@@ -111,7 +111,8 @@ internal fun CellIdentityWcdma.mapCell(subId: Int, connection: IConnection, sign
             connectionStatus = connection,
             signal = signal,
             band = band,
-            subscriptionId = subId
+            subscriptionId = subId,
+            timestamp = timestamp
         )
     }
 }
@@ -129,7 +130,7 @@ internal fun CellIdentityWcdma.mapNetwork(): Network? =
     }
 
 @Suppress("DEPRECATION")
-internal fun GsmCellLocation.mapWcdma(subId: Int, signalStrength: SignalStrength?, network: Network?): ICell? {
+internal fun GsmCellLocation.mapWcdma(subId: Int, signalStrength: SignalStrength?, network: Network?, timestamp: Long?): ICell? {
     val cid = cid.inRangeOrNull(CellWcdma.CID_RANGE)
     val lac = lac.inRangeOrNull(CellWcdma.LAC_RANGE)
     val psc = psc.inRangeOrNull(CellWcdma.PSC_RANGE)
@@ -164,7 +165,8 @@ internal fun GsmCellLocation.mapWcdma(subId: Int, signalStrength: SignalStrength
             signal = signal,
             network = network,
             connectionStatus = PrimaryConnection(),
-            subscriptionId = subId
+            subscriptionId = subId,
+            timestamp = timestamp
         )
     } else null
 }

--- a/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/SignalStrengthMapper.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/SignalStrengthMapper.kt
@@ -15,6 +15,12 @@ fun SignalStrength.toCells(subscriptionId: Int): List<CellNr> =
         val lteSignal = getCellSignalStrengths(CellSignalStrengthLte::class.java)
         val nrSignal = getCellSignalStrengths(CellSignalStrengthNr::class.java)
 
+        val timestamp = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            timestampMillis
+        } else {
+            null
+        }
+
         if (lteSignal.isNotEmpty() && nrSignal.isNotEmpty()) {
             // When we have LTE & NR signal then this could be NR in NSA
             val mappedSignal = nrSignal[0].mapSignal()
@@ -26,7 +32,8 @@ fun SignalStrength.toCells(subscriptionId: Int): List<CellNr> =
                 band = null,
                 signal = mappedSignal,
                 connectionStatus = SecondaryConnection(isGuess = false),
-                subscriptionId = subscriptionId
+                subscriptionId = subscriptionId,
+                timestamp = timestamp
             )
 
             listOf(cell)

--- a/library/src/test/java/cz/mroczis/netmonster/core/feature/ComplexPostprocessingTests.kt
+++ b/library/src/test/java/cz/mroczis/netmonster/core/feature/ComplexPostprocessingTests.kt
@@ -77,7 +77,8 @@ class ComplexPostprocessingTests : SdkTest(Build.VERSION_CODES.P) {
                         ),
                         bandwidth = null,
                         subscriptionId = 1,
-                        connectionStatus = PrimaryConnection()
+                        connectionStatus = PrimaryConnection(),
+                        timestamp = null
                     )
                 )
 

--- a/library/src/test/java/cz/mroczis/netmonster/core/mapper/CellMapperCdmaTest29.kt
+++ b/library/src/test/java/cz/mroczis/netmonster/core/mapper/CellMapperCdmaTest29.kt
@@ -39,7 +39,7 @@ class CellMapperCdmaTest29 : SdkTest(Build.VERSION_CODES.Q) {
     init {
         "Standard CDMA cell" {
             val cell = mockValidCell().let {
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal())
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654)
             }
 
             cell.applyNonNull {
@@ -62,6 +62,7 @@ class CellMapperCdmaTest29 : SdkTest(Build.VERSION_CODES.Q) {
 
                     dbm shouldBe CDMA_RSSI
                 }
+                timestamp shouldBe 1624656855654
             }
         }
 
@@ -71,7 +72,7 @@ class CellMapperCdmaTest29 : SdkTest(Build.VERSION_CODES.Q) {
                 every { it.identity.networkId } returns 65535
                 every { it.identity.systemId } returns 65535
                 every { it.identity.basestationId } returns 0
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal()) shouldBe null
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654) shouldBe null
             }
         }
     }

--- a/library/src/test/java/cz/mroczis/netmonster/core/mapper/CellMapperGsmTest29.kt
+++ b/library/src/test/java/cz/mroczis/netmonster/core/mapper/CellMapperGsmTest29.kt
@@ -40,7 +40,7 @@ class CellMapperGsmTest29 : SdkTest(Build.VERSION_CODES.Q) {
     init {
         "Standard GSM cell" {
             val cell = mockValidCell().let {
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal())
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654)
             }
 
             cell.applyNonNull {
@@ -67,6 +67,8 @@ class CellMapperGsmTest29 : SdkTest(Build.VERSION_CODES.Q) {
                     rssi shouldBe RSSI
                     asu shouldBe 17
                 }
+
+                timestamp shouldBe 1624656855654
             }
         }
 
@@ -80,7 +82,7 @@ class CellMapperGsmTest29 : SdkTest(Build.VERSION_CODES.Q) {
                     Integer.MAX_VALUE // AOSP
                 ).forEach { cid ->
                     every { it.identity.cid } returns cid
-                    it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal()) shouldBe null
+                    it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654) shouldBe null
                 }
             }
         }
@@ -95,7 +97,7 @@ class CellMapperGsmTest29 : SdkTest(Build.VERSION_CODES.Q) {
                     Integer.MAX_VALUE // AOSP
                 ).forEach { lac ->
                     every { it.identity.lac } returns lac
-                    it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal()) shouldBe null
+                    it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654) shouldBe null
                 }
             }
         }
@@ -108,7 +110,7 @@ class CellMapperGsmTest29 : SdkTest(Build.VERSION_CODES.Q) {
                     Integer.MAX_VALUE // AOSP
                 ).forEach { bsic ->
                     every { it.identity.bsic } returns bsic
-                    it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal()).letNonNull { cell ->
+                    it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654).letNonNull { cell ->
                         cell.bsic shouldBe null
                     }
                 }

--- a/library/src/test/java/cz/mroczis/netmonster/core/mapper/CellMapperLteTest29.kt
+++ b/library/src/test/java/cz/mroczis/netmonster/core/mapper/CellMapperLteTest29.kt
@@ -40,7 +40,7 @@ class CellMapperLteTest29 : SdkTest(Build.VERSION_CODES.Q) {
     init {
         "Standard LTE cell" {
             val cell = mockValidCell().let {
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal())
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654)
             }
 
             cell.applyNonNull {
@@ -71,6 +71,7 @@ class CellMapperLteTest29 : SdkTest(Build.VERSION_CODES.Q) {
                     snr shouldBe SNR
                     timingAdvance shouldBe TA
                 }
+                timestamp shouldBe 1624656855654
             }
         }
 
@@ -80,19 +81,19 @@ class CellMapperLteTest29 : SdkTest(Build.VERSION_CODES.Q) {
             // Samsung SM-G935V
             mockValidCell().let {
                 every { it.signal.rsrp } returns 1025
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal())?.signal?.rsrp shouldBe -102.5
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654)?.signal?.rsrp shouldBe -102.5
             }
 
             // Sony E2003
             mockValidCell().let {
                 every { it.signal.rsrp } returns 464
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal())?.signal?.rsrp shouldBe -46.4
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654)?.signal?.rsrp shouldBe -46.4
             }
 
             // Device name I forgot
             mockValidCell().let {
                 every { it.signal.rsrp } returns 25
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal())?.signal?.rsrp shouldBe (-140.0 + 25.0)
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654)?.signal?.rsrp shouldBe (-140.0 + 25.0)
             }
         }
 
@@ -100,24 +101,24 @@ class CellMapperLteTest29 : SdkTest(Build.VERSION_CODES.Q) {
             // Sony E2003
             mockValidCell().let {
                 every { it.signal.rsrq } returns 135
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal())?.signal?.rsrq shouldBe -13.5
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(),1624656855654)?.signal?.rsrq shouldBe -13.5
             }
         }
 
         "Reflection - SNR" {
             mockValidCell().let {
                 every { it.signal.rssnr } returns 300
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal())?.signal?.snr shouldBe null
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654)?.signal?.snr shouldBe null
             }
 
             mockValidCell().let {
                 every { it.signal.rssnr } returns 30
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal())?.signal?.snr shouldBe null
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654)?.signal?.snr shouldBe null
             }
 
             mockValidCell().let {
                 every { it.signal.rssnr } returns 263
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal())?.signal?.snr shouldBe 26.3
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654)?.signal?.snr shouldBe 26.3
             }
         }
 

--- a/library/src/test/java/cz/mroczis/netmonster/core/mapper/CellMapperNrTest29.kt
+++ b/library/src/test/java/cz/mroczis/netmonster/core/mapper/CellMapperNrTest29.kt
@@ -39,7 +39,7 @@ class CellMapperNrTest29 : SdkTest(Build.VERSION_CODES.Q) {
     init {
         "Standard NR cell" {
             val cell = mockValidCell().let {
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal())
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654)
             }
 
             cell.applyNonNull {
@@ -68,6 +68,8 @@ class CellMapperNrTest29 : SdkTest(Build.VERSION_CODES.Q) {
                     csiRsrpAsu shouldBe CSI_RSRP + 140
                     ssRsrpAsu shouldBe SS_RSRP + 140
                 }
+
+                timestamp shouldBe 1624656855654
             }
         }
     }

--- a/library/src/test/java/cz/mroczis/netmonster/core/mapper/CellMapperWcdmaTest29.kt
+++ b/library/src/test/java/cz/mroczis/netmonster/core/mapper/CellMapperWcdmaTest29.kt
@@ -40,7 +40,7 @@ class CellMapperWcdmaTest29 : SdkTest(Build.VERSION_CODES.Q) {
     init {
         "Standard WCDMA cell" {
             val cell = mockValidCell().let {
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal())
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654)
             }
 
             cell.applyNonNull {
@@ -69,6 +69,8 @@ class CellMapperWcdmaTest29 : SdkTest(Build.VERSION_CODES.Q) {
                     ecno shouldBe ECNO
                     ecio shouldBe null
                 }
+
+                timestamp shouldBe 1624656855654
             }
         }
 
@@ -78,7 +80,7 @@ class CellMapperWcdmaTest29 : SdkTest(Build.VERSION_CODES.Q) {
             mockValidCell().let {
                 every { it.identity.cid } returns 1
                 every { it.identity.lac } returns 0
-                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal()).letNonNull {
+                it.identity.mapCell(0, it.info.mapConnection(), it.signal.mapSignal(), 1624656855654).letNonNull {
                     it.ci shouldBe null
                     it.lac shouldBe null
                     it.psc shouldBe PSC


### PR DESCRIPTION
This PR is an implementation for #17, It didn't seem that bad so I thought I'd give it a try. 

Basically I'm using the following for getting the timestamp, whenever possible. Ordered the same as their priority: 
1. [`getTimestampMillis`](https://developer.android.com/reference/android/telephony/CellInfo#getTimestampMillis())
    * In  `CellInfoMapper`
2. [`getTimestamp`](https://developer.android.com/reference/android/telephony/CellInfo#getTimeStamp())
    * In  `CellInfoMapper`
3. [`SignalStrength.getTimestampMillis`](https://developer.android.com/reference/android/telephony/SignalStrength#getTimestampMillis())
    * In `CellLocationMapper`, though I think I might be wrong here because if I understand correctly `CellLocationMapper` gets used for older versions and I'm attempting to read the timestamp from `SignalStrength`, simply because I have access to it. But that's a version 30 addition, so it might always be defaulted to `null`. 

✅ All the tests pass.

I've also added the timestamp in the example application. 
![image](https://user-images.githubusercontent.com/10492324/123489594-54618580-d5e0-11eb-802f-4cd0a3027f9a.png)
Tested on a Google Pixel 4A, with Koodo as the Carrier in Richmond Hill, Ontario, Canada. 
