### PR TITLE
Add Postprocessor that detects bandwidth on Exynos. Closes #11

### DIFF
--- a/library/src/main/java/cz/mroczis/netmonster/core/NetMonster.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/NetMonster.kt
@@ -48,6 +48,9 @@ internal class NetMonster(
         add(SignalStrengthPostprocessor { subId ->
             getTelephony(subId).getCellLocation().firstOrNull()
         }) // might add more signal strength indicators
+        add(CellBandwidthPostprocessor { subId ->
+            getTelephony(subId).getServiceState()
+        })
         add(PhysicalChannelPostprocessor { subId ->
             getPhysicalChannelConfiguration(subId)
         })

--- a/library/src/main/java/cz/mroczis/netmonster/core/feature/postprocess/CellBandwidthPostprocessor.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/feature/postprocess/CellBandwidthPostprocessor.kt
@@ -1,0 +1,32 @@
+package cz.mroczis.netmonster.core.feature.postprocess
+
+import android.os.Build
+import android.telephony.ServiceState
+import cz.mroczis.netmonster.core.model.cell.CellLte
+import cz.mroczis.netmonster.core.model.cell.ICell
+import cz.mroczis.netmonster.core.model.connection.PrimaryConnection
+
+/**
+ * Adds cell bandwidth from [ServiceState] to the cell objects.
+ * [ServiceState].cellBandwidths even reports bandwidths for secondary cells, but determining
+ * the order is complicated.
+ */
+class CellBandwidthPostprocessor(
+    private val serviceStateGetter: (Int) -> ServiceState?
+) : ICellPostprocessor {
+
+    override fun postprocess(list: List<ICell>): List<ICell> =
+        list.toMutableList().map {cell ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                if (cell is CellLte && cell.connectionStatus is PrimaryConnection) {
+                    serviceStateGetter.invoke(cell.subscriptionId)?.let { serviceState ->
+                        cell.copy(bandwidth = serviceState.cellBandwidths.firstOrNull())
+                    } ?: cell
+                } else {
+                    cell
+                }
+            } else {
+                cell
+            }
+        }
+}


### PR DESCRIPTION
Based on #11. As detection of secondary cells is not well supported anyways on Samsung, i have only implemented this for the primary cells. Not sure if this is the desired approach as it adds another call to TelephonyManager.getServiceState that might delay scanning of the values.

![photo1626690831](https://user-images.githubusercontent.com/1783250/126147361-a0f78107-ebfa-46ee-a61e-c56bba1a3f2e.jpeg)