### PR TITLE
Solved exceeded the number of permissible registered listeners

### DIFF
--- a/library/src/main/java/cz/mroczis/netmonster/core/feature/config/TelephonyManagerListeners.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/feature/config/TelephonyManagerListeners.kt
@@ -77,6 +77,7 @@ internal fun <T> TelephonyManager.requestSingleUpdate(
             listen(it, PhoneStateListener.LISTEN_NONE)
         }
     }
+    listen(listener, PhoneStateListener.LISTEN_NONE)
 
     return result
 }


### PR DESCRIPTION
I was able to reproduce the issue with Samsung Galaxy A51 (Android 11) with forced to use 2G network only in our project. We use getCells() from various threads with 1s refresh rate and it seems that it has problem to unregister listener properly in some cases. When I added that line, then app continue and problem does not occur anymore for now. But I am not 100% sure if it is correct solution.