### PR TITLE
Reduce plmn postprocessor false positives with dual SIM and MOCN

### DIFF
--- a/library/src/main/java/cz/mroczis/netmonster/core/feature/postprocess/PlmnPostprocessor.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/feature/postprocess/PlmnPostprocessor.kt
@@ -112,8 +112,8 @@ class PlmnPostprocessor : ICellPostprocessor {
                         0 -> null
                         1 -> channelMatches[0].network
                         // More networks per one channel, this happens when cell list is not sorted
-                        // in that case we rely just on PrimaryConnection if's available.
-                        else -> channelMatches.firstOrNull { it.connection is PrimaryConnection }?.network
+                        // in that case we rely just on PrimaryConnection if's available and unique.
+                        else -> channelMatches.singleOrNull { it.connection is PrimaryConnection }?.network
                     }
                 }
             }


### PR DESCRIPTION
When there are two SIMs connected to two cells with the same channel but different MNC, the postprocessor copies the PLMN of the first cell to the second, but this could be wrong if the two SIMs access the same network with different MNC (MOCN).
This change avoids this problem by not changing the PLMN if there're multiple primary cells with the same channel.

This is the simplest solution I come up, I know this could cause regressions on devices that don't properly support dual SIM, but I didn't want to "unnecessarily" complicate the code 

All test passed, expect "Reflection - SNR" most likely due https://github.com/mroczis/netmonster-core/commit/9b0bd3399b15b12810b8d469b17b5e2f5df17abf