### PR TITLE
Filter out invalid NR cells on Mediatek devices

### DIFF
--- a/library/src/main/java/cz/mroczis/netmonster/core/feature/postprocess/InvalidCellsPostprocessor.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/feature/postprocess/InvalidCellsPostprocessor.kt
@@ -2,9 +2,11 @@ package cz.mroczis.netmonster.core.feature.postprocess
 
 import cz.mroczis.netmonster.core.model.cell.CellGsm
 import cz.mroczis.netmonster.core.model.cell.CellLte
+import cz.mroczis.netmonster.core.model.cell.CellNr
 import cz.mroczis.netmonster.core.model.cell.ICell
 import cz.mroczis.netmonster.core.model.connection.PrimaryConnection
 import cz.mroczis.netmonster.core.util.isHuawei
+import cz.mroczis.netmonster.core.util.isMediatek
 import cz.mroczis.netmonster.core.util.isSamsung
 
 /**
@@ -24,6 +26,9 @@ class InvalidCellsPostprocessor : ICellPostprocessor {
         // - a7y18ltexx, API 28
         // - beyond1lteeea, API 29
         .filterNot { it is CellLte && isSamsung() && it.band?.number == 1 && it.connectionStatus !is PrimaryConnection && it.signal.rsrp != null && it.signal.rsrq == null }
+        // Mediatek devices return these fake NR (primary) cells, in NSA mode, most likely when they attempt to connect to an NR cell or have just disconnected.
+        // The only valid values are PCI, PLMN and NR-ARFCN, NCI is 0 or 268435455 (filtered out by CellMapperNR), RSRP -44 and RSRQ -3
+        .filterNot { it is CellNr && isMediatek() && it.nci == null && it.signal.ssRsrp == -44 && it.signal.ssRsrq == -3 && it.signal.csiRsrp == -44 && it.signal.csiRsrq == -3 }
         .toList()
 
 }

--- a/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperNr.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperNr.kt
@@ -18,7 +18,8 @@ import cz.mroczis.netmonster.core.util.inRangeOrNull
 @TargetApi(Build.VERSION_CODES.Q)
 internal fun CellIdentityNr.mapCell(subId: Int, connection: IConnection, signal: SignalNr?, timestamp: Long): CellNr? {
     val network = Network.map(mccString, mncString)
-    val nci = nci.inRangeOrNull(CellNr.CID_RANGE)?.takeIf { it != Int.MAX_VALUE.toLong() }
+    // 268435455 is LTE max CID and unfortunately used as N/A value on many MTK devices...
+    val nci = nci.inRangeOrNull(CellNr.CID_RANGE)?.takeIf { it != Int.MAX_VALUE.toLong() && it != 268435455L }
     val tac = tac.inRangeOrNull(CellNr.TAC_RANGE)
     val pci = pci.inRangeOrNull(CellNr.PCI_RANGE)
     val arfcn = nrarfcn.inRangeOrNull(BandNr.DOWNLINK_EARFCN_RANGE)

--- a/library/src/main/java/cz/mroczis/netmonster/core/util/Android.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/util/Android.kt
@@ -66,3 +66,4 @@ fun Int.toDbm() = -113 + 2 * this
 
 fun isHuawei() = Build.MANUFACTURER.equals("huawei", ignoreCase = true)
 fun isSamsung() = Build.MANUFACTURER.equals("samsung", ignoreCase = true)
+fun isMediatek() = Build.HARDWARE?.startsWith("mt", ignoreCase = true) ?: false


### PR DESCRIPTION
As part of the larger "flashing" issue (#13), many if not all Mediatek 5G devices, report NR cells with NCI 0 or 268435455 (max LTE CID) as primary cells in NSA mode.

In some cases these cells are completely bogus, they've the PCI and NR-ARFCN of an old or future NR cell (most likely the cell they are connecting/disconnecting to), TAC is N/A, SINR N/A, SS-RSRP -44 dBm, CSI-RSRP -44, dBm, SS-RSRQ -3 dB, CSI-RSRQ -3 dB.

I have received reports of this issue from users with the following devices:
Xiaomi M2007J22G (API 29 and 30)
Oneplus DN2103 (API 30)
Oppo CPH2211 (API 30)
Realme RMX2111 (API 29 and 30)

This is an example:
![photo_2022-04-09_15-47-11](https://user-images.githubusercontent.com/3463028/162589600-f6999129-b9e1-4edd-9e1a-ea2ea3415f29.jpg)


Due to the previously mentioned "flashing" issue, it's really hard (not being able to test it personally) to understand how and what has changed in NR detection. So I would be glad to see a beta version of netmonster and/or netmonster-core with these changes, it would make it much easier to collect feedback

