### PR TITLE
Filter out NR TAC 16777215

### DIFF
--- a/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellNr.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/model/cell/CellNr.kt
@@ -58,7 +58,10 @@ data class CellNr(
          * Correct min TAC value is 0. Some Samsung phones use it as N/A value.
          */
         const val TAC_MIN = 1L
-        const val TAC_MAX = 16_777_215L
+        /**
+         * Correct max TAC value is 16777215. Pixel 6 use it as N/A value.
+         */
+        const val TAC_MAX = 16_777_214L
 
         const val PCI_MIN = 0L
         const val PCI_MAX = 1007L


### PR DESCRIPTION
Pixel 6 use it as N/A value for NSA cells:

![photo_2022-04-30_13-56-54](https://user-images.githubusercontent.com/3463028/166685198-72ca9a6a-264a-4cf6-9d65-c547615b0332.jpg)
![photo_2022-04-20_17-07-57](https://user-images.githubusercontent.com/3463028/166685235-b06a8ffa-3ac2-4bf1-9752-3fb66fb2782c.jpg)

The behavior seems similar to some mediatek devices (i.e. only one NR cell, no LTE cells), but less flashing/random.
Unfortunately I didn't get any detailed report or netmonster log, I've only those two (cropped) screenshots




