### PR TITLE
Fix WCDMA typos

### DIFF
--- a/library/src/main/java/cz/mroczis/netmonster/core/model/signal/SignalWcdma.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/model/signal/SignalWcdma.kt
@@ -49,7 +49,7 @@ data class SignalWcdma(
      * Unit: dB
      */
     @SinceSdk(Build.VERSION_CODES.M)
-    @IntRange(from = ECNO_MIN, to = ECIO_MAX)
+    @IntRange(from = ECIO_MIN, to = ECIO_MAX)
     val ecio: Int?
 ) : ISignal {
 

--- a/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperWcdma.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/CellMapperWcdma.kt
@@ -45,7 +45,7 @@ internal fun CellSignalStrengthWcdma.mapSignal(): SignalWcdma {
         val rssiFromAsu = asuLevel.toDbm().inRangeOrNull(SignalWcdma.RSSI_RANGE) // ASU -> DBM
         val rssiFromDbm = dbm.inRangeOrNull(SignalWcdma.RSSI_RANGE)
         // In real world those two values must be equal
-        if (rssiFromAsu != rssiFromAsu) {
+        if (rssiFromDbm != rssiFromAsu) {
             rssiFromDbm ?: rssiFromAsu
         } else rssiFromDbm
     }


### PR DESCRIPTION
## SignalWcdma.kt

Change from ECNO_MIN to ECIO_MIN

## CellMapperWcdma

Compare dbm to asu instead of asu to itself. 

Note: I'm not sure what the purpose of the comparison is since it looks like we could just always return the `dbm ?: asu` statement if the idea is to fall back to asu when dbm is null, but regardless I've kept the original logic for now