### PR TITLE
Improve MOCN postprocessor 

### DIFF
--- a/library/src/main/java/cz/mroczis/netmonster/core/feature/postprocess/MocnNetworkPostprocessor.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/feature/postprocess/MocnNetworkPostprocessor.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import androidx.annotation.RequiresPermission
 import cz.mroczis.netmonster.core.model.Network
 import cz.mroczis.netmonster.core.model.cell.*
+import cz.mroczis.netmonster.core.model.connection.NoneConnection
 import cz.mroczis.netmonster.core.subscription.ISubscriptionManagerCompat
 
 /**
@@ -34,7 +35,7 @@ class MocnNetworkPostprocessor(
         
         return list.toMutableList().map { cell ->
             val suggestedNetwork = subscriptions[cell.subscriptionId]
-            if ((cell is CellLte || cell.network == null) && suggestedNetwork != null && suggestedNetwork != cell.network) {
+            if ((cell is CellLte && cell.connectionStatus !is NoneConnection || cell.network == null) && suggestedNetwork != null && suggestedNetwork != cell.network) {
                 cell.let(PlmnSwitcher(suggestedNetwork))
             } else {
                 cell

--- a/library/src/main/java/cz/mroczis/netmonster/core/feature/postprocess/MocnNetworkPostprocessor.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/feature/postprocess/MocnNetworkPostprocessor.kt
@@ -35,7 +35,10 @@ class MocnNetworkPostprocessor(
         
         return list.toMutableList().map { cell ->
             val suggestedNetwork = subscriptions[cell.subscriptionId]
-            if ((cell is CellLte && cell.connectionStatus !is NoneConnection || cell.network == null) && suggestedNetwork != null && suggestedNetwork != cell.network) {
+            if (suggestedNetwork != null && suggestedNetwork != cell.network &&
+                (cell.network == null || cell is CellLte && cell.connectionStatus !is NoneConnection
+                        && cell.network?.mcc == suggestedNetwork.mcc)
+            ) {
                 cell.let(PlmnSwitcher(suggestedNetwork))
             } else {
                 cell


### PR DESCRIPTION
This should help mitigate #44 
 
I got several reports with mRegistered=NO & mCellConnectionStatus=0, some have mRegistered=YES & mCellConnectionStatus=0 (or INVALID) though, but better than nothing :)

I was in doubt between !is NoneConnection and is PrimaryConnection, which one do you think is better?