### PR TITLE
InvalidSecondaryCellsPostprocessor: Fix duplicated cells issue

### DIFF
--- a/library/src/main/java/cz/mroczis/netmonster/core/feature/postprocess/InvalidSecondaryCellsPostprocessor.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/feature/postprocess/InvalidSecondaryCellsPostprocessor.kt
@@ -26,7 +26,7 @@ class InvalidSecondaryCellsPostprocessor : ICellPostprocessor {
                     }
                 }
             } else {
-                list
+                cells
             }
         }
 

--- a/library/src/test/java/cz/mroczis/netmonster/core/feature/ComplexPostprocessingTests.kt
+++ b/library/src/test/java/cz/mroczis/netmonster/core/feature/ComplexPostprocessingTests.kt
@@ -57,6 +57,7 @@ class ComplexPostprocessingTests : SdkTest(Build.VERSION_CODES.P) {
             val postprocessors = listOf(
                 MocnNetworkPostprocessor(subManager, networkOperatorSimulation, serviceStateSimulation),
                 InvalidCellsPostprocessor(),
+                InvalidSecondaryCellsPostprocessor(),
                 PrimaryCellPostprocessor(),
                 SubDuplicitiesPostprocessor(subManager, networkOperatorSimulation),
                 PlmnPostprocessor()
@@ -258,6 +259,7 @@ class ComplexPostprocessingTests : SdkTest(Build.VERSION_CODES.P) {
             val postprocessors = listOf(
                 MocnNetworkPostprocessor(subManager, networkOperatorSimulation, serviceStateSimulation),
                 InvalidCellsPostprocessor(),
+                InvalidSecondaryCellsPostprocessor(),
                 PrimaryCellPostprocessor(),
                 SubDuplicitiesPostprocessor(subManager, networkOperatorSimulation),
                 PlmnPostprocessor()

--- a/library/src/test/java/cz/mroczis/netmonster/core/feature/ComplexPostprocessingTests29.kt
+++ b/library/src/test/java/cz/mroczis/netmonster/core/feature/ComplexPostprocessingTests29.kt
@@ -149,6 +149,7 @@ class ComplexPostprocessingTests29 : SdkTest(Build.VERSION_CODES.Q) {
             val postprocessors = listOf(
                 MocnNetworkPostprocessor(subManager, networkOperatorSimulation, serviceStateSimulation),
                 InvalidCellsPostprocessor(),
+                InvalidSecondaryCellsPostprocessor(),
                 PrimaryCellPostprocessor(),
                 SubDuplicitiesPostprocessor(subManager, networkOperatorSimulation),
                 PlmnPostprocessor()


### PR DESCRIPTION
Trivial fix to avoid duplication of cells. I also added the new postprocessors to complex postprocessing tests, so we have a minimum of test coverage for it