### PR TITLE
SignalNr: Use ssRsrp as default dbm

### DIFF
--- a/library/src/main/java/cz/mroczis/netmonster/core/model/signal/SignalNr.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/model/signal/SignalNr.kt
@@ -58,7 +58,7 @@ data class SignalNr(
     internal constructor() : this(null, null, null, null, null, null)
 
     override val dbm: Int?
-        get() = csiRsrp
+        get() = ssRsrp
 
     /**
      * Same as [csiRsrp] just different unit.

--- a/library/src/test/java/cz/mroczis/netmonster/core/mapper/CellMapperNrTest29.kt
+++ b/library/src/test/java/cz/mroczis/netmonster/core/mapper/CellMapperNrTest29.kt
@@ -57,7 +57,7 @@ class CellMapperNrTest29 : SdkTest(Build.VERSION_CODES.Q) {
                 }
 
                 signal.apply {
-                    dbm shouldBe CSI_RSRP
+                    dbm shouldBe SS_RSRP
                     csiRsrp shouldBe CSI_RSRP
                     csiRsrq shouldBe CSI_RSRQ
                     csiSinr shouldBe CSI_SINR


### PR DESCRIPTION
Almost all devices return valid ssRsrp, while csiRsrp is often invalid

See also: https://android.googlesource.com/platform/frameworks/base/+/1f107358319d65dff6793adffdc4789c8d924b7e