### PR TITLE
Combine data from Registration Info with data from other sources

### DIFF
--- a/library/src/main/java/cz/mroczis/netmonster/core/NetMonster.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/NetMonster.kt
@@ -132,9 +132,9 @@ internal class NetMonster(
 
         } else emptyList()
 
-        val mergedOldNew = oldAndNewCellMerger.merge(oldApi, newApi, context.isDisplayOn(), subscriptions)
-        val mergedWithSignal = signalMerger.merge(mergedOldNew, signalApi)
-        return networkRegistrationMerger.merge(mergedWithSignal, networkRegistrationApi)
+        val mergedWithRegistration = networkRegistrationMerger.merge(newApi, networkRegistrationApi)
+        val mergedOldNew = oldAndNewCellMerger.merge(oldApi, mergedWithRegistration, context.isDisplayOn(), subscriptions)
+        return signalMerger.merge(mergedOldNew, signalApi)
     }
 
     @RequiresPermission(

--- a/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/SignalStrengthMapper.kt
+++ b/library/src/main/java/cz/mroczis/netmonster/core/telephony/mapper/cell/SignalStrengthMapper.kt
@@ -4,13 +4,17 @@ import android.os.Build
 import android.telephony.CellSignalStrengthLte
 import android.telephony.CellSignalStrengthNr
 import android.telephony.SignalStrength
+import cz.mroczis.netmonster.core.model.cell.CellLte
 import cz.mroczis.netmonster.core.model.cell.CellNr
+import cz.mroczis.netmonster.core.model.cell.ICell
+import cz.mroczis.netmonster.core.model.connection.PrimaryConnection
 import cz.mroczis.netmonster.core.model.connection.SecondaryConnection
 
 /**
- * Attempts to detect NR in NSA mode. Requires valid LTE and NR signal
+ * Attempts to detect NR in NSA mode. Requires valid LTE and NR signal.
+ * Returns NR cell and primary LTE cell (only signal)
  */
-internal fun SignalStrength.toCells(subscriptionId: Int): List<CellNr> =
+internal fun SignalStrength.toCells(subscriptionId: Int): List<ICell> =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         val lteSignal = getCellSignalStrengths(CellSignalStrengthLte::class.java)
         val nrSignal = getCellSignalStrengths(CellSignalStrengthNr::class.java)
@@ -23,19 +27,35 @@ internal fun SignalStrength.toCells(subscriptionId: Int): List<CellNr> =
 
         if (lteSignal.isNotEmpty() && nrSignal.isNotEmpty()) {
             // When we have LTE & NR signal then this could be NR in NSA
-            val mappedSignal = nrSignal[0].mapSignal()
-            val cell = CellNr(
+            val mappedSignalNr = nrSignal[0].mapSignal()
+            val mappedSignalLte = lteSignal[0].mapSignal()
+
+            val cellNr = CellNr(
                 network = null,
                 nci = null,
                 tac = null,
                 pci = null,
                 band = null,
-                signal = mappedSignal,
+                signal = mappedSignalNr,
                 connectionStatus = SecondaryConnection(isGuess = false),
                 subscriptionId = subscriptionId,
                 timestamp = timestamp
             )
 
-            listOf(cell)
+            val cellLte = CellLte(
+                network = null,
+                eci = null,
+                tac = null,
+                pci = null,
+                band = null,
+                aggregatedBands = emptyList(),
+                bandwidth = null,
+                signal = mappedSignalLte,
+                connectionStatus = PrimaryConnection(),
+                subscriptionId = subscriptionId,
+                timestamp = timestamp,
+            )
+
+            listOf(cellNr, cellLte)
         } else emptyList()
     } else emptyList()

--- a/library/src/test/java/cz/mroczis/netmonster/core/feature/merge/CellSignalMergerTest.kt
+++ b/library/src/test/java/cz/mroczis/netmonster/core/feature/merge/CellSignalMergerTest.kt
@@ -14,60 +14,62 @@ class CellSignalMergerTest : SdkTest(Build.VERSION_CODES.Q) {
     private val merger = CellSignalMerger()
 
     init {
-        val newApi = listOf(
-            CellNr(
-                connectionStatus = NoneConnection(),
-                subscriptionId = 1,
-                nci = null,
-                tac = null,
-                pci = 221,
-                band = BandTableNr.map(645312),
-                network = Network.map(222, 10),
-                signal = SignalNr(
-                    csiRsrp = null,
-                    csiRsrq = null,
-                    csiSinr = null,
-                    ssRsrp = null,
-                    ssRsrq = null,
-                    ssSinr = 18
-                ),
-                timestamp = null,
+        "Merge nr cells from signalApi and newApi" {
+            val newApi = listOf(
+                CellNr(
+                    connectionStatus = NoneConnection(),
+                    subscriptionId = 1,
+                    nci = null,
+                    tac = null,
+                    pci = 221,
+                    band = BandTableNr.map(645312),
+                    network = Network.map(222, 10),
+                    signal = SignalNr(
+                        csiRsrp = null,
+                        csiRsrq = null,
+                        csiSinr = null,
+                        ssRsrp = null,
+                        ssRsrq = null,
+                        ssSinr = 18
+                    ),
+                    timestamp = null,
+                )
             )
-        )
 
-        val signalApi = listOf(
-            CellNr(
-                connectionStatus = NoneConnection(),
-                subscriptionId = 1,
-                nci = null,
-                tac = null,
-                pci = null,
-                band = null,
-                network = null,
-                signal = SignalNr(
-                    csiRsrp = null,
-                    csiRsrq = null,
-                    csiSinr = null,
-                    ssRsrp = -101,
-                    ssRsrq = -9,
-                    ssSinr = 19
-                ),
-                timestamp = null,
+            val signalApi = listOf(
+                CellNr(
+                    connectionStatus = NoneConnection(),
+                    subscriptionId = 1,
+                    nci = null,
+                    tac = null,
+                    pci = null,
+                    band = null,
+                    network = null,
+                    signal = SignalNr(
+                        csiRsrp = null,
+                        csiRsrq = null,
+                        csiSinr = null,
+                        ssRsrp = -101,
+                        ssRsrq = -9,
+                        ssSinr = 19
+                    ),
+                    timestamp = null,
+                )
             )
-        )
 
-        val merged = merger.merge(newApi, signalApi)
-        merged.size shouldBe 1
-        (merged[0] as CellNr).apply {
-            pci shouldBe 221
-            band shouldBe BandTableNr.map(645312)
-            network shouldBe Network.map(222, 10)
-            signal.csiRsrp shouldBe null
-            signal.csiRsrq shouldBe null
-            signal.csiSinr shouldBe null
-            signal.ssRsrp shouldBe -101
-            signal.ssRsrq shouldBe -9
-            signal.ssSinr shouldBe 18
+            val merged = merger.merge(newApi, signalApi)
+            merged.size shouldBe 1
+            (merged[0] as CellNr).apply {
+                pci shouldBe 221
+                band shouldBe BandTableNr.map(645312)
+                network shouldBe Network.map(222, 10)
+                signal.csiRsrp shouldBe null
+                signal.csiRsrq shouldBe null
+                signal.csiSinr shouldBe null
+                signal.ssRsrp shouldBe -101
+                signal.ssRsrq shouldBe -9
+                signal.ssSinr shouldBe 18
+            }
         }
     }
 

--- a/library/src/test/java/cz/mroczis/netmonster/core/feature/merge/ComplexMergerTest.kt
+++ b/library/src/test/java/cz/mroczis/netmonster/core/feature/merge/ComplexMergerTest.kt
@@ -1,0 +1,316 @@
+package cz.mroczis.netmonster.core.feature.merge
+
+import android.os.Build
+import cz.mroczis.netmonster.core.SdkTest
+import cz.mroczis.netmonster.core.db.BandTableLte
+import cz.mroczis.netmonster.core.db.BandTableNr
+import cz.mroczis.netmonster.core.model.Network
+import cz.mroczis.netmonster.core.model.cell.CellLte
+import cz.mroczis.netmonster.core.model.cell.CellNr
+import cz.mroczis.netmonster.core.model.connection.NoneConnection
+import cz.mroczis.netmonster.core.model.connection.PrimaryConnection
+import cz.mroczis.netmonster.core.model.connection.SecondaryConnection
+import cz.mroczis.netmonster.core.model.signal.SignalLte
+import cz.mroczis.netmonster.core.model.signal.SignalNr
+import io.kotlintest.shouldBe
+
+class ComplexMergerTest : SdkTest(Build.VERSION_CODES.R) {
+
+    private val registrationMerger = CellNetworkRegistrationMerger()
+    private val signalMerger = CellSignalMerger()
+
+    init {
+        "Dual SIM, 1st SIM NR NSA, 2nd SIM LTE. LTE cells missing in new api for 1st SIM." {
+            val newApi = listOf(
+                CellNr(
+                    connectionStatus = NoneConnection(),
+                    subscriptionId = 1,
+                    nci = null,
+                    tac = null,
+                    pci = 221,
+                    band = BandTableNr.map(645312),
+                    network = Network.map(222, 10),
+                    signal = SignalNr(
+                        csiRsrp = null,
+                        csiRsrq = null,
+                        csiSinr = null,
+                        ssRsrp = null,
+                        ssRsrq = null,
+                        ssSinr = 18
+                    ),
+                    timestamp = null,
+                ),
+                CellLte(
+                    connectionStatus = PrimaryConnection(),
+                    subscriptionId = 2,
+                    eci = 100001,
+                    tac = 1005,
+                    pci = 400,
+                    band = BandTableLte.map(6200),
+                    aggregatedBands = emptyList(),
+                    bandwidth = null,
+                    network = Network.map(222, 99),
+                    signal = SignalLte(
+                        rsrp = -90.0,
+                        rsrq = -7.0,
+                        rssi = -80,
+                        snr = 10.0,
+                        cqi = null,
+                        timingAdvance = null
+                    ),
+                    timestamp = null,
+                )
+            )
+
+            val registration = listOf(
+                CellLte(
+                    connectionStatus = PrimaryConnection(),
+                    subscriptionId = 1,
+                    eci = 2022412,
+                    tac = 1001,
+                    pci = 231,
+                    band = BandTableLte.map(6400),
+                    aggregatedBands = emptyList(),
+                    bandwidth = null,
+                    network = Network.map(222, 10),
+                    signal = SignalLte.EMPTY,
+                    timestamp = null
+                ),
+                CellLte(
+                    connectionStatus = PrimaryConnection(),
+                    subscriptionId = 2,
+                    eci = 100001,
+                    tac = 1005,
+                    pci = 400,
+                    band = BandTableLte.map(6200),
+                    aggregatedBands = emptyList(),
+                    bandwidth = null,
+                    network = Network.map(222, 99),
+                    signal = SignalLte.EMPTY,
+                    timestamp = null
+                ),
+            )
+
+            val signalApi = listOf(
+                CellNr(
+                    connectionStatus = SecondaryConnection(false),
+                    subscriptionId = 1,
+                    nci = null,
+                    tac = null,
+                    pci = null,
+                    band = null,
+                    network = null,
+                    signal = SignalNr(
+                        csiRsrp = null,
+                        csiRsrq = null,
+                        csiSinr = null,
+                        ssRsrp = -101,
+                        ssRsrq = -9,
+                        ssSinr = 19
+                    ),
+                    timestamp = null,
+                ),
+                CellLte(
+                    connectionStatus = PrimaryConnection(),
+                    subscriptionId = 1,
+                    eci = null,
+                    tac = null,
+                    pci = null,
+                    band = null,
+                    aggregatedBands = emptyList(),
+                    bandwidth = null,
+                    network = null,
+                    signal = SignalLte(
+                        rsrp = -83.0,
+                        rsrq = -8.0,
+                        rssi = -69,
+                        snr = 6.0,
+                        cqi = 12,
+                        timingAdvance = 3
+                    ),
+                    timestamp = null
+                )
+            )
+
+            val registrationMerged = registrationMerger.merge(newApi, registration)
+            registrationMerged.size shouldBe 3
+            val signalMerged = signalMerger.merge(registrationMerged, signalApi)
+            signalMerged.size shouldBe 3
+
+            val sims = signalMerged.groupBy { it.subscriptionId }
+            // Two sims
+            sims.size shouldBe 2
+            sims[1]?.let {
+                it.size shouldBe 2
+                (it[0] as CellNr).apply {
+                    pci shouldBe 221
+                    band shouldBe BandTableNr.map(645312)
+                    network shouldBe Network.map(222, 10)
+                    signal.csiRsrp shouldBe null
+                    signal.csiRsrq shouldBe null
+                    signal.csiSinr shouldBe null
+                    signal.ssRsrp shouldBe -101
+                    signal.ssRsrq shouldBe -9
+                    signal.ssSinr shouldBe 18
+                    connectionStatus shouldBe SecondaryConnection(false)
+                }
+                (it[1] as CellLte).apply {
+                    eci shouldBe 2022412
+                    pci shouldBe 231
+                    band shouldBe BandTableLte.map(6400)
+                    network shouldBe Network.map(222, 10)
+                    signal.rsrp shouldBe -83.0
+                    signal.rsrq shouldBe -8.0
+                    signal.snr shouldBe 6.0
+                    signal.cqi shouldBe 12
+                    signal.timingAdvance shouldBe 3
+                    connectionStatus shouldBe PrimaryConnection()
+                }
+            }
+            sims[2]?.let {
+                it.size shouldBe 1
+                // CellLte must be equal to the one from new api
+                (it[0] as CellLte) shouldBe newApi[1]
+            }
+        }
+
+        "Dual SIM, 1st SIM LTE, 2nd SIM NR NSA. NR cells missing in new api." {
+            val newApi = listOf(
+                CellLte(
+                    connectionStatus = PrimaryConnection(),
+                    subscriptionId = 1,
+                    eci = 200001,
+                    tac = 2005,
+                    pci = 200,
+                    band = BandTableLte.map(1850),
+                    aggregatedBands = emptyList(),
+                    bandwidth = null,
+                    network = Network.map(222, 10),
+                    signal = SignalLte(
+                        rsrp = -101.0,
+                        rsrq = -16.0,
+                        rssi = -84,
+                        snr = 3.2,
+                        cqi = 5,
+                        timingAdvance = 7
+                    ),
+                    timestamp = null
+                ),
+                CellLte(
+                    connectionStatus = PrimaryConnection(),
+                    subscriptionId = 2,
+                    eci = 506279,
+                    tac = 1111,
+                    pci = 200,
+                    band = BandTableLte.map(1650),
+                    aggregatedBands = emptyList(),
+                    bandwidth = null,
+                    network = Network.map(222, 50),
+                    signal = SignalLte(
+                        rsrp = -90.0,
+                        rsrq = -7.0,
+                        rssi = -80,
+                        snr = 10.0,
+                        cqi = null,
+                        timingAdvance = null
+                    ),
+                    timestamp = null
+                )
+            )
+
+            val registration = listOf(
+                CellLte(
+                    connectionStatus = PrimaryConnection(),
+                    subscriptionId = 1,
+                    eci = 200001,
+                    tac = 2005,
+                    pci = 200,
+                    band = BandTableLte.map(1850),
+                    aggregatedBands = emptyList(),
+                    bandwidth = null,
+                    network = Network.map(222, 10),
+                    signal = SignalLte.EMPTY,
+                    timestamp = null
+                ),
+                CellLte(
+                    connectionStatus = PrimaryConnection(),
+                    subscriptionId = 2,
+                    eci = 506279,
+                    tac = 1111,
+                    pci = 200,
+                    band = BandTableLte.map(1650),
+                    aggregatedBands = emptyList(),
+                    bandwidth = null,
+                    network = Network.map(222, 50),
+                    signal = SignalLte.EMPTY,
+                    timestamp = null
+                ),
+            )
+
+            val signalApi = listOf(
+                CellNr(
+                    connectionStatus = SecondaryConnection(false),
+                    subscriptionId = 2,
+                    nci = null,
+                    tac = null,
+                    pci = null,
+                    band = null,
+                    network = null,
+                    signal = SignalNr(
+                        csiRsrp = null,
+                        csiRsrq = null,
+                        csiSinr = null,
+                        ssRsrp = -130,
+                        ssRsrq = -5,
+                        ssSinr = 28
+                    ),
+                    timestamp = null,
+                ),
+                CellLte(
+                    connectionStatus = PrimaryConnection(),
+                    subscriptionId = 2,
+                    eci = null,
+                    tac = null,
+                    pci = null,
+                    band = null,
+                    aggregatedBands = emptyList(),
+                    bandwidth = null,
+                    network = null,
+                    signal = SignalLte(
+                        rsrp = -83.0,
+                        rsrq = -8.0,
+                        rssi = -69,
+                        snr = 6.0,
+                        cqi = 12,
+                        timingAdvance = 3
+                    ),
+                    timestamp = null
+                )
+            )
+
+            val registrationMerged = registrationMerger.merge(newApi, registration)
+            // Registration must not add any lte cell
+            registrationMerged.size shouldBe 2
+
+            val signalMerged = signalMerger.merge(registrationMerged, signalApi)
+            signalMerged.size shouldBe 3
+
+            val sims = signalMerged.groupBy { it.subscriptionId }
+            // Two sims
+            sims.size shouldBe 2
+            sims[1]?.let {
+                it.size shouldBe 1
+                // CellLte must be equal to the one from new api
+                (it[0] as CellLte) shouldBe newApi[0]
+            }
+            sims[2]?.let {
+                it.size shouldBe 2
+                // CellLte must be equal to the one from new api
+                (it[0] as CellLte) shouldBe newApi[1]
+
+                // CellNr must be equal to the one from signal api
+                (it[1] as CellNr) shouldBe signalApi[0]
+            }
+        }
+    }
+}


### PR DESCRIPTION
When LTE data is missing in new APIs (e.g. Pixel 7 in NR NSA) a developer has to choose between LTE without frequencies (from cell location) or LTE without signal (from registration information).

I tried to overcome that, with two approaches:
1. Merge AllCellInfo and RegistrationInfo right after postprocessing. So data from registration info can be combined with LTE signal from Cell Location.
2. Get LTE Signal from Signal Strenght source and combine it with data from registration info (in NR NSA)

An alternative approach would be to merge  RegistrationInfo and AllCellInfo before Signal Strenght Postprocessor